### PR TITLE
Command Issues

### DIFF
--- a/lib/flay/cli.rb
+++ b/lib/flay/cli.rb
@@ -10,12 +10,15 @@ class Flay::CLI < Thor
     :chef_path,
     type: :string,
     desc: "The path that contains your knife.rb file",
-    default: "~/.chef-sweeper"
+    default: "~/.chef-sweeper/"
   )
   desc "link [--chef-path=PATH]", "symlinks .chef to --chef-path"
   long_desc "Creates a symlink in the current directory from .chef to --chef-path"
   def link
-    create_link File.join(Dir.pwd, ".chef"), options.fetch("chef_path")
+    target_path = options.fetch("chef_path")
+    target_path << "/" unless target_path.end_with?("/")
+
+    create_link File.join(Dir.pwd, ".chef"), target_path
   end
 
   desc "version", "display the current version"

--- a/shared/flavor/flay/files/default/Berksfile
+++ b/shared/flavor/flay/files/default/Berksfile
@@ -1,4 +1,4 @@
+source "https://berks.sweeper.io"
 source "https://supermarket.chef.io"
-cookbook "core", github: "sweeperio/chef-core"
 
 metadata

--- a/shared/flavor/flay/resources/template.rb
+++ b/shared/flavor/flay/resources/template.rb
@@ -7,6 +7,7 @@ property :use_helpers, [TrueClass, FalseClass], default: true
 action :create do
   template new_resource.name do
     source new_resource.source
+    helper(:sanitized_cookbook_name) { cookbook_name.sub(/\Achef-/, "") }
     helpers new_resource.helpers
   end
 end
@@ -14,6 +15,7 @@ end
 action :create_if_missing do
   template new_resource.name do
     source new_resource.source
+    helper(:sanitized_cookbook_name) { cookbook_name.sub(/\Achef-/, "") }
     helpers new_resource.helpers
     action :create_if_missing
   end

--- a/shared/flavor/flay/templates/default/README.md.erb
+++ b/shared/flavor/flay/templates/default/README.md.erb
@@ -1,3 +1,3 @@
-# <%= cookbook_name %>
+# <%= sanitized_cookbook_name %>
 
 TODO: Enter the cookbook description here.

--- a/shared/flavor/flay/templates/default/kitchen.yml.erb
+++ b/shared/flavor/flay/templates/default/kitchen.yml.erb
@@ -13,5 +13,5 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[<%= cookbook_name %>]
+      - recipe[<%= sanitized_cookbook_name %>]
     attributes:

--- a/shared/flavor/flay/templates/default/metadata.rb.erb
+++ b/shared/flavor/flay/templates/default/metadata.rb.erb
@@ -10,6 +10,8 @@ version          "0.1.0"
 
 supports "ubuntu"
 
+depends "core", "~> 0.0"
+
 chef_version ">= 12.5" if respond_to?(:chef_version)
 source_url "YOUR SOURCE REPO URL" if respond_to?(:source_url)
 issues_url "WHERE TO LOG ISSUES" if respond_to?(:issues_url)

--- a/shared/flavor/flay/templates/default/metadata.rb.erb
+++ b/shared/flavor/flay/templates/default/metadata.rb.erb
@@ -1,10 +1,10 @@
 # rubocop:disable Style/SingleSpaceBeforeFirstArg
-name             "<%= cookbook_name %>"
+name             "<%= sanitized_cookbook_name %>"
 maintainer       "<%= copyright_holder %>"
 maintainer_email "<%= email %>"
 license          "<%= license %>"
-description      "Installs/Configures <%= cookbook_name %>"
-long_description "Installs/Configures <%= cookbook_name %>"
+description      "Installs/Configures <%= sanitized_cookbook_name %>"
+long_description "Installs/Configures <%= sanitized_cookbook_name %>"
 version          "0.1.0"
 # rubocop:enable Style/SingleSpaceBeforeFirstArg
 

--- a/shared/flavor/flay/templates/default/recipe.rb.erb
+++ b/shared/flavor/flay/templates/default/recipe.rb.erb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: <%= cookbook_name %>
+# Cookbook Name:: <%= cookbook_name.sub(/\Achef-/, "") %>
 # Recipe:: <%= recipe_name %>
 #
 <%= license_description("#").rstrip %>

--- a/shared/flavor/flay/templates/default/recipe.rb.erb
+++ b/shared/flavor/flay/templates/default/recipe.rb.erb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: <%= cookbook_name.sub(/\Achef-/, "") %>
+# Cookbook Name:: <%= sanitized_cookbook_name %>
 # Recipe:: <%= recipe_name %>
 #
 <%= license_description("#").rstrip %>

--- a/shared/flavor/flay/templates/default/recipe_spec.rb.erb
+++ b/shared/flavor/flay/templates/default/recipe_spec.rb.erb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: <%= cookbook_name %>
+# Cookbook Name:: <%= sanitized_cookbook_name %>
 # Spec:: <%= recipe_name %>
 #
 <%= license_description("#").rstrip %>
 
-describe "<%= cookbook_name %>::<%= recipe_name %>" do
+describe "<%= sanitized_cookbook_name %>::<%= recipe_name %>" do
   cached(:chef_run) do
     runner = ChefSpec::SoloRunner.new
     runner.converge(described_recipe)

--- a/shared/flavor/flay/templates/default/serverspec_default_spec.rb.erb
+++ b/shared/flavor/flay/templates/default/serverspec_default_spec.rb.erb
@@ -1,4 +1,4 @@
 require "spec_helper"
 
-describe "<%= cookbook_name %>" do
+describe "<%= sanitized_cookbook_name %>" do
 end

--- a/spec/flay/cli_spec.rb
+++ b/spec/flay/cli_spec.rb
@@ -26,7 +26,7 @@ describe Flay::CLI do
     it "creates a symlink for .chef to default target" do
       expect_any_instance_of(described_class).to receive(:create_link).with(
         File.join(Dir.pwd, ".chef"),
-        "~/.chef-sweeper"
+        "~/.chef-sweeper/"
       )
 
       invoke
@@ -35,7 +35,16 @@ describe Flay::CLI do
     it "uses --chef-path option as target when supplied" do
       expect_any_instance_of(described_class).to receive(:create_link).with(
         File.join(Dir.pwd, ".chef"),
-        "/spec/.chef"
+        "/spec/.chef/"
+      )
+
+      described_class.start(%w(link --chef-path=/spec/.chef/))
+    end
+
+    it "will ensure the symlink links directories" do
+      expect_any_instance_of(described_class).to receive(:create_link).with(
+        File.join(Dir.pwd, ".chef"),
+        "/spec/.chef/"
       )
 
       described_class.start(%w(link --chef-path=/spec/.chef))


### PR DESCRIPTION
# Wut
- The link command is not ensuring the symlink is a directory. This made it so that `.chef` was a bad symlink. 
- The generate recipe command was using the folder name as the cookbook name. It's common to prefix the directory/repo with `chef-`, but that should not be used in the templates. Fixes #4 
