### PR TITLE
Update with swpr prefix

### DIFF
--- a/features/generate_cookbook.feature
+++ b/features/generate_cookbook.feature
@@ -8,7 +8,7 @@ Feature: chef generate cookbook
     And I set the environment variable "CHEFGEN_FLAVOR" to "flay"
     When I generate a cookbook named "foo"
     Then the exit status should be 0
-    And I cd to "foo"
+    And I cd to "chef-swpr_foo"
 
   Scenario: expected cookbook files are created
     Then the following files should exist:
@@ -34,6 +34,10 @@ Feature: chef generate cookbook
       | test/integration/helpers/serverspec/spec_helper.rb   |
       | test/unit/recipes/default_spec.rb                    |
       | test/unit/spec_helper.rb                             |
+
+  Scenario: cookbook_name in templates includes swpr_ prefix
+    Then the file "README.md" should contain "# swpr_foo"
+    And the file "metadata.rb" should match /^name\s*"swpr_foo"/
 
   Scenario: rake tasks are available
     When I bundle install

--- a/features/generate_recipe.feature
+++ b/features/generate_recipe.feature
@@ -3,8 +3,8 @@ Feature: chef generate recipe
   Verifies that `chef generate recipe` works as expected
 
   Background:
-    Given an empty directory named "foo/recipes"
-    When I cd to "foo"
+    Given an empty directory named "chef-swpr_foo/recipes"
+    When I cd to "chef-swpr_foo"
     And I generate a recipe named "test"
 
   Scenario: expected files are created
@@ -14,17 +14,17 @@ Feature: chef generate recipe
       | test/unit/spec_helper.rb       |
 
   Scenario: recipe contains header comments
-    Then the file "recipes/test.rb" should contain "# Cookbook Name:: foo"
+    Then the file "recipes/test.rb" should contain "# Cookbook Name:: swpr_foo"
     And the file "recipes/test.rb" should contain "# Recipe:: test"
 
   Scenario: spec contains header comments
-    Then the file "test/unit/recipes/test_spec.rb" should contain "# Cookbook Name:: foo"
+    Then the file "test/unit/recipes/test_spec.rb" should contain "# Cookbook Name:: swpr_foo"
     And the file "test/unit/recipes/test_spec.rb" should contain "# Spec:: test"
 
   Scenario: spec file contains basic plumbing
     Then the file "test/unit/recipes/test_spec.rb" should contain
     """
-    describe "foo::test" do
+    describe "swpr_foo::test" do
       cached(:chef_run) do
         runner = ChefSpec::SoloRunner.new
         runner.converge(described_recipe)

--- a/lib/flay/commands/release.rb
+++ b/lib/flay/commands/release.rb
@@ -38,7 +38,7 @@ class Flay::Commands::Release < Thor::Group
 
   def berks_upload
     say "Uploading cookbook to chef server...", :green
-    shell_exec("chef exec berks upload")
+    shell_exec("chef exec berks upload --except=test integration")
   end
 
   def all_done

--- a/shared/flavor/flay/libraries/context.rb
+++ b/shared/flavor/flay/libraries/context.rb
@@ -1,0 +1,23 @@
+module Flay # rubocop:disable Style/ClassAndModuleChildren
+  class Context < SimpleDelegator
+    alias_method :context, :__getobj__
+
+    def self.current
+      @current ||= Context.new(ChefDK::Generator.context)
+    end
+
+    module Helper
+      extend Forwardable
+
+      delegate %i(cookbook_name directory_name) => :flay_cookbook
+
+      private
+
+      def flay_cookbook
+        @flay_cookbook ||= Flay::Cookbook.new(ChefDK::Generator.context.cookbook_name)
+      end
+    end
+
+    include Helper
+  end
+end

--- a/shared/flavor/flay/libraries/cookbook.rb
+++ b/shared/flavor/flay/libraries/cookbook.rb
@@ -1,0 +1,24 @@
+module Flay # rubocop:disable Style/ClassAndModuleChildren
+  class Cookbook
+    PREFIX    = "chef-".freeze
+    NAMESPACE = "swpr_".freeze
+    PATTERN   = /\A(#{PREFIX})?(#{NAMESPACE})?(.*)\z/.freeze
+
+    attr_reader :prefix, :namespace, :name
+
+    def initialize(name)
+      match      = PATTERN.match(name)
+      @prefix    = match[1] || PREFIX
+      @namespace = match[2] || NAMESPACE
+      @name      = match[3]
+    end
+
+    def cookbook_name
+      @cookbook_name ||= "#{namespace}#{name}"
+    end
+
+    def directory_name
+      @directory_name ||= "#{prefix}#{namespace}#{name}"
+    end
+  end
+end

--- a/shared/flavor/flay/recipes/cookbook.rb
+++ b/shared/flavor/flay/recipes/cookbook.rb
@@ -1,5 +1,5 @@
-context      = ChefDK::Generator.context
-cookbook_dir = File.join(context.cookbook_root, context.cookbook_name)
+context      = Flay::Context.current
+cookbook_dir = File.join(context.cookbook_root, context.directory_name)
 kitchen_dir  = File.join(cookbook_dir, "test", "integration")
 
 # Common Cookbook Things

--- a/shared/flavor/flay/recipes/recipe.rb
+++ b/shared/flavor/flay/recipes/recipe.rb
@@ -1,5 +1,5 @@
-context          = ChefDK::Generator.context
-cookbook_dir     = File.join(context.cookbook_root, context.cookbook_name)
+context          = Flay::Context.current
+cookbook_dir     = File.join(context.cookbook_root, context.directory_name)
 recipe_path      = File.join(cookbook_dir, "recipes", "#{context.new_file_basename}.rb")
 spec_helper_path = File.join(cookbook_dir, "test", "unit", "spec_helper.rb")
 spec_path        = File.join(cookbook_dir, "test", "unit", "recipes", "#{context.new_file_basename}_spec.rb")

--- a/shared/flavor/flay/resources/template.rb
+++ b/shared/flavor/flay/resources/template.rb
@@ -2,25 +2,20 @@ default_action :create_if_missing
 
 property :name, String, name_property: true
 property :source, String
-property :use_helpers, [TrueClass, FalseClass], default: true
 
 action :create do
   template new_resource.name do
     source new_resource.source
-    helper(:sanitized_cookbook_name) { cookbook_name.sub(/\Achef-/, "") }
-    helpers new_resource.helpers
+    helpers ChefDK::Generator::TemplateHelper
+    helpers Flay::Context::Helper
   end
 end
 
 action :create_if_missing do
   template new_resource.name do
     source new_resource.source
-    helper(:sanitized_cookbook_name) { cookbook_name.sub(/\Achef-/, "") }
-    helpers new_resource.helpers
+    helpers ChefDK::Generator::TemplateHelper
+    helpers Flay::Context::Helper
     action :create_if_missing
   end
-end
-
-def helpers
-  use_helpers ? ChefDK::Generator::TemplateHelper : []
 end

--- a/shared/flavor/flay/templates/default/LICENSE.erb
+++ b/shared/flavor/flay/templates/default/LICENSE.erb
@@ -1,1 +1,1 @@
-<%= license_description("#").rstrip %>
+<%= license_description.rstrip %>

--- a/shared/flavor/flay/templates/default/README.md.erb
+++ b/shared/flavor/flay/templates/default/README.md.erb
@@ -1,8 +1,8 @@
-# <%= sanitized_cookbook_name %>
+# <%= cookbook_name %>
 
-[![Build Status](https://travis-ci.org/sweeperio/<%= cookbook_name %>.svg?branch=master)](https://travis-ci.org/sweeperio/<%= cookbook_name %>)
+[![Build Status](https://travis-ci.org/sweeperio/<%= directory_name %>.svg?branch=master)](https://travis-ci.org/sweeperio/<%= directory_name %>)
 
-Install/configure <%= sanitized_cookbook_name %>
+Install/configure <%= cookbook_name %>
 
 ## What This Does
 
@@ -16,15 +16,15 @@ Install/configure <%= sanitized_cookbook_name %>
 
 | attribute | description | default |
 |-----------|-------------|---------|
-| `node["<%= sanitized_cookbook_name %>"]["value"]` | some description | `""` |
+| `node["<%= cookbook_name %>"]["value"]` | some description | `""` |
 
 ## Recipes
 
-### <%= sanitized_cookbook_name %>::default
+### <%= cookbook_name %>::default
 
 TODO: description
 
-**Usage:** add `recipe[<%= sanitized_cookbook_name %>]` to your run list.
+**Usage:** add `recipe[<%= cookbook_name %>]` to your run list.
 
 ## License
 

--- a/shared/flavor/flay/templates/default/kitchen.yml.erb
+++ b/shared/flavor/flay/templates/default/kitchen.yml.erb
@@ -13,5 +13,5 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[<%= sanitized_cookbook_name %>]
+      - recipe[<%= cookbook_name %>]
     attributes:

--- a/shared/flavor/flay/templates/default/metadata.rb.erb
+++ b/shared/flavor/flay/templates/default/metadata.rb.erb
@@ -1,9 +1,9 @@
 # rubocop:disable Style/SingleSpaceBeforeFirstArg
-name             "<%= sanitized_cookbook_name %>"
+name             "<%= cookbook_name %>"
 maintainer       "<%= copyright_holder %>"
 maintainer_email "<%= email %>"
 license          "<%= license %>"
-description      "Installs/Configures <%= sanitized_cookbook_name %>"
+description      "Installs/Configures <%= cookbook_name %>"
 long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version          "0.1.0"
 # rubocop:enable Style/SingleSpaceBeforeFirstArg
@@ -13,5 +13,5 @@ supports "ubuntu"
 depends "swpr_core", "~> 0.0"
 
 chef_version ">= 12.5" if respond_to?(:chef_version)
-source_url "YOUR SOURCE REPO URL" if respond_to?(:source_url)
-issues_url "WHERE TO LOG ISSUES" if respond_to?(:issues_url)
+source_url "https://github.com/YOUR_GH_ACCOUNT/<%= directory_name %>" if respond_to?(:source_url)
+issues_url "https://github.com/YOUR_GH_ACCOUNT/<%= directory_name %>/issues" if respond_to?(:issues_url)

--- a/shared/flavor/flay/templates/default/metadata.rb.erb
+++ b/shared/flavor/flay/templates/default/metadata.rb.erb
@@ -10,7 +10,7 @@ version          "0.1.0"
 
 supports "ubuntu"
 
-depends "core", "~> 0.0"
+depends "swpr_core", "~> 0.0"
 
 chef_version ">= 12.5" if respond_to?(:chef_version)
 source_url "YOUR SOURCE REPO URL" if respond_to?(:source_url)

--- a/shared/flavor/flay/templates/default/metadata.rb.erb
+++ b/shared/flavor/flay/templates/default/metadata.rb.erb
@@ -13,5 +13,5 @@ supports "ubuntu"
 depends "swpr_core", "~> 0.0"
 
 chef_version ">= 12.5" if respond_to?(:chef_version)
-source_url "https://github.com/YOUR_GH_ACCOUNT/<%= directory_name %>" if respond_to?(:source_url)
-issues_url "https://github.com/YOUR_GH_ACCOUNT/<%= directory_name %>/issues" if respond_to?(:issues_url)
+source_url "https://github.com/sweeperio/<%= directory_name %>" if respond_to?(:source_url)
+issues_url "https://github.com/sweeperio/<%= directory_name %>/issues" if respond_to?(:issues_url)

--- a/shared/flavor/flay/templates/default/recipe.rb.erb
+++ b/shared/flavor/flay/templates/default/recipe.rb.erb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: <%= sanitized_cookbook_name %>
+# Cookbook Name:: <%= cookbook_name %>
 # Recipe:: <%= recipe_name %>
 #
 <%= license_description("#").rstrip %>

--- a/shared/flavor/flay/templates/default/recipe_spec.rb.erb
+++ b/shared/flavor/flay/templates/default/recipe_spec.rb.erb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: <%= sanitized_cookbook_name %>
+# Cookbook Name:: <%= cookbook_name %>
 # Spec:: <%= recipe_name %>
 #
 <%= license_description("#").rstrip %>
 
-describe "<%= sanitized_cookbook_name %>::<%= recipe_name %>" do
+describe "<%= cookbook_name %>::<%= recipe_name %>" do
   cached(:chef_run) do
     runner = ChefSpec::SoloRunner.new
     runner.converge(described_recipe)

--- a/shared/flavor/flay/templates/default/serverspec_default_spec.rb.erb
+++ b/shared/flavor/flay/templates/default/serverspec_default_spec.rb.erb
@@ -1,4 +1,4 @@
 require "spec_helper"
 
-describe "<%= sanitized_cookbook_name %>" do
+describe "<%= cookbook_name %>" do
 end

--- a/spec/flay/commands/release_spec.rb
+++ b/spec/flay/commands/release_spec.rb
@@ -2,7 +2,7 @@ describe Flay::Commands::Release, :command, :shell_commands do
   let(:shell_commands) do
     {
       berks_install: ["chef exec berks install", "", ""],
-      berks_upload: ["chef exec berks upload", "", ""],
+      berks_upload: ["chef exec berks upload --except=test integration", "", ""],
       git_root: ["git rev-parse --show-toplevel", Dir.pwd, ""],
       git_clean: ["git diff --exit-code", "", ""],
       git_committed: ["git diff-index --quiet --cached HEAD", "", ""],

--- a/spec/libraries/cookbook_spec.rb
+++ b/spec/libraries/cookbook_spec.rb
@@ -1,0 +1,33 @@
+describe Flay::Cookbook do
+  shared_examples "a cookbook with a name" do
+    let(:cookbook) { described_class.new(name) }
+
+    it "sets the cookbook_name correctly" do
+      expect(cookbook.cookbook_name).to eq("swpr_foo")
+    end
+
+    it "sets the directory_name correctly" do
+      expect(cookbook.directory_name).to eq("chef-swpr_foo")
+    end
+  end
+
+  context "with chef-swpr_ prefix supplied" do
+    let(:name) { "chef-swpr_foo" }
+    it_behaves_like "a cookbook with a name"
+  end
+
+  context "with chef- prefix supplied" do
+    let(:name) { "chef-foo" }
+    it_behaves_like "a cookbook with a name"
+  end
+
+  context "with swpr_ prefix supplied" do
+    let(:name) { "swpr_foo" }
+    it_behaves_like "a cookbook with a name"
+  end
+
+  context "without any prefix" do
+    let(:name) { "foo" }
+    it_behaves_like "a cookbook with a name"
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,4 +12,5 @@ require "chef/knife/data_bag_decrypt"
 require "flay"
 require "pry"
 
+require "./shared/flavor/flay/libraries/cookbook"
 Dir["./spec/support/**/*.rb"].each { |f| require f }


### PR DESCRIPTION
# The Problem

There are some issues when there are name conflicts with our custom berksapi and the supermarket. For example, depending on `ruby "~> 0.0"` was incorrectly grabbing `ruby 0.10.0` from the supermarket rather than `ruby 0.1.0` from our berksapi.
# The Solution

Using a prefix for our cookbooks. The convention is that cookbooks will be named `swpr_<cookbook>`. Repos will be `chef-swpr_<cookbook>`.

I've updated the templates to use this during cookbook/recipe generation
